### PR TITLE
Add `ruleset_id` to `(Beatmap)Tags` model

### DIFF
--- a/ossapi/enums.py
+++ b/ossapi/enums.py
@@ -512,6 +512,7 @@ class BeatmapTag(Model):
     description: str
     id: int
     name: str
+    ruleset_id: Optional[int]
 
 
 class Failtimes(Model):

--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -1602,6 +1602,7 @@ class Tag(Model):
     id: int
     name: str
     description: str
+    ruleset_id: Optional[int]
 
 
 class Tags(Model):


### PR DESCRIPTION
I don't believe these are currently used (always returns null), but was added in https://github.com/ppy/osu-web/pull/12067 and will be used in the client.

I didn't realise we already had a `BeatmapTag` model in `enums.py` when implementing #92, feel free to consolodate these into one model :3