### PR TITLE
Fix `Get Scores` endpoint parameters

### DIFF
--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -2589,15 +2589,15 @@ class Ossapi:
 
     @request(Scope.PUBLIC, category="scores")
     def scores(
-        self, ruleset: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
+        self, mode: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
     ) -> Scores:
         """
         Returns most recent 1000 passed scores across all users.
 
         Parameters
         ----------
-        ruleset
-            The ruleset (gamemode) to get scores for.
+        mode
+            The mode to get scores for.
         cursor_string
             Cursor for pagination.
 
@@ -2606,7 +2606,7 @@ class Ossapi:
         Implements the `Get Scores
         <https://osu.ppy.sh/docs/index.html#get-scores97>`__ endpoint.
         """
-        params = {"ruleset": ruleset, "cursor_string": cursor_string}
+        params = {"ruleset": mode, "cursor_string": cursor_string}
         return self._get(Scores, "/scores", params)
 
     @request(Scope.PUBLIC, category="scores")

--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -2604,7 +2604,7 @@ class Ossapi:
         Notes
         -----
         Implements the `Get Scores
-        <https://osu.ppy.sh/docs/index.html#get-scores94>`__ endpoint.
+        <https://osu.ppy.sh/docs/index.html#get-scores97>`__ endpoint.
         """
         params = {"ruleset": ruleset, "cursor_string": cursor_string}
         return self._get(Scores, "/scores", params)

--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -2589,15 +2589,15 @@ class Ossapi:
 
     @request(Scope.PUBLIC, category="scores")
     def scores(
-        self, mode: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
+        self, ruleset: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
     ) -> Scores:
         """
         Returns most recent 1000 passed scores across all users.
 
         Parameters
         ----------
-        mode
-            The mode to get scores for.
+        ruleset
+            The ruleset (gamemode) to get scores for.
         cursor_string
             Cursor for pagination.
 
@@ -2606,7 +2606,7 @@ class Ossapi:
         Implements the `Get Scores
         <https://osu.ppy.sh/docs/index.html#get-scores94>`__ endpoint.
         """
-        params = {"mode": mode, "cursor_string": cursor_string}
+        params = {"ruleset": ruleset, "cursor_string": cursor_string}
         return self._get(Scores, "/scores", params)
 
     @request(Scope.PUBLIC, category="scores")

--- a/ossapi/ossapiv2_async.py
+++ b/ossapi/ossapiv2_async.py
@@ -2674,15 +2674,15 @@ class OssapiAsync:
 
     @request(Scope.PUBLIC, category="scores")
     async def scores(
-        self, mode: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
+        self, ruleset: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
     ) -> Scores:
         """
         Returns most recent 1000 passed scores across all users.
 
         Parameters
         ----------
-        mode
-            The mode to get scores for.
+        ruleset
+            The ruleset (gamemode) to get scores for.
         cursor_string
             Cursor for pagination.
 
@@ -2691,7 +2691,7 @@ class OssapiAsync:
         Implements the `Get Scores
         <https://osu.ppy.sh/docs/index.html#get-scores94>`__ endpoint.
         """
-        params = {"mode": mode, "cursor_string": cursor_string}
+        params = {"ruleset": ruleset, "cursor_string": cursor_string}
         return await self._get(Scores, "/scores", params)
 
     @request(Scope.PUBLIC, category="scores")

--- a/ossapi/ossapiv2_async.py
+++ b/ossapi/ossapiv2_async.py
@@ -2674,15 +2674,15 @@ class OssapiAsync:
 
     @request(Scope.PUBLIC, category="scores")
     async def scores(
-        self, ruleset: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
+        self, mode: Optional[GameModeT] = None, *, cursor_string: Optional[str] = None
     ) -> Scores:
         """
         Returns most recent 1000 passed scores across all users.
 
         Parameters
         ----------
-        ruleset
-            The ruleset (gamemode) to get scores for.
+        mode
+            The mode to get scores for.
         cursor_string
             Cursor for pagination.
 
@@ -2691,7 +2691,7 @@ class OssapiAsync:
         Implements the `Get Scores
         <https://osu.ppy.sh/docs/index.html#get-scores97>`__ endpoint.
         """
-        params = {"ruleset": ruleset, "cursor_string": cursor_string}
+        params = {"ruleset": mode, "cursor_string": cursor_string}
         return await self._get(Scores, "/scores", params)
 
     @request(Scope.PUBLIC, category="scores")

--- a/ossapi/ossapiv2_async.py
+++ b/ossapi/ossapiv2_async.py
@@ -2689,7 +2689,7 @@ class OssapiAsync:
         Notes
         -----
         Implements the `Get Scores
-        <https://osu.ppy.sh/docs/index.html#get-scores94>`__ endpoint.
+        <https://osu.ppy.sh/docs/index.html#get-scores97>`__ endpoint.
         """
         params = {"ruleset": ruleset, "cursor_string": cursor_string}
         return await self._get(Scores, "/scores", params)


### PR DESCRIPTION
Currently, the endpoint ignores the `mode` parameter. Turns out its name should be `ruleset`.

[osu! API docs](https://osu.ppy.sh/docs/index.html#get-scores97)
[osu-web code](https://github.com/ppy/osu-web/blob/master/app/Http/Controllers/ScoresController.php#L160)