### PR TITLE
Add pagination params for `room_leaderboard()` in async implementation

### DIFF
--- a/ossapi/ossapiv2.py
+++ b/ossapi/ossapiv2.py
@@ -2498,7 +2498,7 @@ class Ossapi:
 
     @request(Scope.PUBLIC, category="rooms")
     def room_leaderboard(
-        self, room_id: RoomIdT, limit: Optional[int] = None, page: Optional[int] = None
+        self, room_id: RoomIdT,  limit: Optional[int] = None, page: Optional[int] = None
     ) -> RoomLeaderboard:
         """
         Get the leaderboard of a room.
@@ -2509,13 +2509,13 @@ class Ossapi:
             The room to get the leaderboard of.
         limit
             Maximum number of room scores to return.
-        offset
-            Offset for pagination.
+        page
+            Pagination for results.
 
         Notes
         -----
         Implements the `Get Room Leaderboard
-        <https://osu.ppy.sh/docs/index.html#roomsroomleaderboard>`__ endpoint.
+        <https://osu.ppy.sh/docs/index.html#get-apiv2roomsroomleaderboard>`__ endpoint.
         """
         params = {"limit": limit, "page": page}
         return self._get(

--- a/ossapi/ossapiv2_async.py
+++ b/ossapi/ossapiv2_async.py
@@ -2591,7 +2591,9 @@ class OssapiAsync:
         return await self._get(Room, f"/rooms/{room_id}")
 
     @request(Scope.PUBLIC, category="rooms")
-    async def room_leaderboard(self, room_id: RoomIdT) -> RoomLeaderboard:
+    async def room_leaderboard(
+        self, room_id: RoomIdT, limit: Optional[int] = None, page: Optional[int] = None
+    ) -> RoomLeaderboard:
         """
         Get the leaderboard of a room.
 
@@ -2599,13 +2601,20 @@ class OssapiAsync:
         ----------
         room_id
             The room to get the leaderboard of.
+        limit
+            Maximum number of room scores to return.
+        page
+            Pagination for results.
 
         Notes
         -----
         Implements the `Get Room Leaderboard
-        <https://osu.ppy.sh/docs/index.html#roomsroomleaderboard>`__ endpoint.
+        <https://osu.ppy.sh/docs/index.html#get-apiv2roomsroomleaderboard>`__ endpoint.
         """
-        return await self._get(RoomLeaderboard, f"/rooms/{room_id}/leaderboard")
+        params = {"limit": limit, "page": page}
+        return await self._get(
+            RoomLeaderboard, f"/rooms/{room_id}/leaderboard", params=params
+        )
 
     @request(Scope.PUBLIC, requires_user=True, category="rooms")
     async def rooms(


### PR DESCRIPTION
Updates `room_leaderboard()` to match the sync implementation.

Also updates docstring for the sync version to match the method's params - feel free to change if you'd like!