### PR TITLE
Fix SeasonStatistics.total_score type

### DIFF
--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -715,7 +715,7 @@ class SeasonStatistics(Model):
     division: SeasonDivision
     season: Season
     rank: int
-    total_score: int
+    total_score: float
 
 
 # return-value wrapper for https://osu.ppy.sh/docs/index.html#get-users.


### PR DESCRIPTION
Not sure how score can be a float, but apparently it can!

https://github.com/ppy/osu-web/blob/f46806bb81eb0d3b0807c70bf8e3dc13f0783ec9/app/Models/UserSeasonScoreAggregate.php#L18