### PR TITLE
Change types order in ranking union of Rankings model

### DIFF
--- a/ossapi/models.py
+++ b/ossapi/models.py
@@ -738,7 +738,7 @@ class Rankings(Model):
     beatmapsets: Optional[list[Beatmapset]]
     cursor: CursorT
     cursor_string: Optional[str]
-    ranking: Union[list[UserStatistics], list[CountryStatistics]]
+    ranking: Union[list[CountryStatistics], list[UserStatistics]]
     spotlight: Optional[Spotlight]
     total: Optional[int]
 


### PR DESCRIPTION
If union is used for a type, the type is selected based on first deserialization success during forward iteration through the type list. Apparently `CountryStatistics` JSON is compatible with the `UserStatistics` one, so the latter was selected for all ranking types. Because of this `Ossapi.ranking(type=RankingType.COUNTRY)` returns broken result consisting of almost-empty `UserStatistics` instances.

The fix is rather awkward, but the alternative is mid-size refactoring which I'd like to avoid as of now.